### PR TITLE
[hermes-agent] ci: add 2-minute wait after multipass install

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,6 +65,12 @@ jobs:
           sudo snap install multipass
         if: "${{ inputs.multipass-image != '' }}"
 
+      - name: Wait for Multipass to settle
+        run: |
+          echo "Waiting 2 minutes after Multipass installation to let services settle"
+          sleep 120
+        if: "${{ inputs.multipass-image != '' }}"
+
       - name: Launch an LXD container
         run: |
           set -x # for debug purpose


### PR DESCRIPTION
[hermes-agent]

Add a 2-minute delay after `snap install multipass` before launching the VM.

This is an attempt to reduce the startup race seen in CI when Multipass cert/runtime files are not ready immediately.

Reference: https://github.com/canonical/multipass/issues/5015
